### PR TITLE
Switch OutlinedButton from primary to foregroundColor

### DIFF
--- a/lib/widgets/poll_buttons.dart
+++ b/lib/widgets/poll_buttons.dart
@@ -22,7 +22,7 @@ class PollButtonsWidget extends StatelessWidget {
       /// Calls the passed callback to capture response.
       onPressed: onPressed,
       style: OutlinedButton.styleFrom(
-        primary: Theme.of(context).primaryColor,
+        foregroundColor: Theme.of(context).primaryColor,
         shape: borderShape,
         side: BorderSide(
           color: Theme.of(context).primaryColor,


### PR DESCRIPTION
`primary` was removed in 3.19.

https://docs.flutter.dev/release/breaking-changes/3-16-deprecations